### PR TITLE
feat: add Detection.msg for object detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Motors.msg"
   "msg/Remote.msg"
   "msg/EndEffector.msg"
+  "msg/Detection.msg"
   DEPENDENCIES geometry_msgs
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,13 +9,15 @@ endif()
 find_package(geometry_msgs REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(vision_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Motors.msg"
   "msg/Remote.msg"
   "msg/EndEffector.msg"
   "msg/Detection.msg"
-  DEPENDENCIES geometry_msgs
+  "srv/BatchDetections2D.srv"
+  DEPENDENCIES geometry_msgs vision_msgs
 )
 
 if(BUILD_TESTING)

--- a/msg/Detection.msg
+++ b/msg/Detection.msg
@@ -1,0 +1,10 @@
+int32    detection
+builtin_interfaces/Time time
+string   type
+string   name
+float32  x
+float32  y
+float32  z
+string   robot
+string     mode
+float32  confidence

--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,10 @@
   <author email="guglielmo.bergatto@gmail.com">Guglielmo Bergatto</author>
 
   <depend>geometry_msgs</depend>
+
+  <build_depend>vision_msgs</build_depend>
+  <exec_depend>vision_msgs</exec_depend>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>

--- a/srv/BatchDetections2D.srv
+++ b/srv/BatchDetections2D.srv
@@ -1,0 +1,8 @@
+# Request
+string                          robot
+string                          mode               # 'A' or 'T'
+vision_msgs/Detection2DArray    detections
+---
+# Response
+bool                            success
+string                          message            # filepath or error


### PR DESCRIPTION
- Define custom Detection.msg for object recognition data.
This PR is a subpart of: [https://github.com/Team-Isaac-Polito/reseq_ros2/pull/78](url)