### PR TITLE
feat: detection manager interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,19 +5,36 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# find dependencies
-find_package(geometry_msgs REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+
+# dependencies used by messages/services
+find_package(std_msgs REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(vision_msgs REQUIRED)
 
-rosidl_generate_interfaces(${PROJECT_NAME}
+# list message files
+set(msg_files
   "msg/Motors.msg"
   "msg/Remote.msg"
   "msg/EndEffector.msg"
   "msg/Detection.msg"
+)
+
+# list service files (added)
+set(srv_files
   "srv/BatchDetections2D.srv"
-  DEPENDENCIES geometry_msgs vision_msgs
+  "srv/SetMode.srv"
+  "srv/GetStatus.srv"
+  "srv/ComputeCoordinate.srv"
+)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  ${srv_files}
+  DEPENDENCIES builtin_interfaces std_msgs sensor_msgs geometry_msgs vision_msgs
 )
 
 if(BUILD_TESTING)

--- a/msg/Detection.msg
+++ b/msg/Detection.msg
@@ -5,8 +5,8 @@ string name
 string robot
 string mode
 float32 confidence
-uint32 xmin
-uint32 ymin
+int32 xmin
+int32 ymin
 uint32 width
 uint32 height
 float32 depth_center          # meters (depth at bounding-box center)

--- a/msg/Detection.msg
+++ b/msg/Detection.msg
@@ -1,10 +1,13 @@
-int32    detection
-builtin_interfaces/Time time
-string   type
-string   name
-float32  x
-float32  y
-float32  z
-string   robot
-string     mode
-float32  confidence
+std_msgs/Header header        # stamp + frame_id (camera frame)
+int32 detection
+string type
+string name
+string robot
+string mode
+float32 confidence
+uint32 xmin
+uint32 ymin
+uint32 width
+uint32 height
+float32 depth_center          # meters (depth at bounding-box center)
+string camera_frame

--- a/package.xml
+++ b/package.xml
@@ -10,15 +10,23 @@
   <author email="milenayahya@gmail.com">Milena Yahya</author>
   <author email="guglielmo.bergatto@gmail.com">Guglielmo Bergatto</author>
 
-  <depend>geometry_msgs</depend>
+  <!-- Runtime and build dependencies required by messages/services -->
+  <build_depend>rosidl_default_generators</build_depend>
+  <build_depend>builtin_interfaces</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
 
+  <!-- keep vision_msgs if used by existing messages -->
   <build_depend>vision_msgs</build_depend>
   <exec_depend>vision_msgs</exec_depend>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
-  <buildtool_depend>rosidl_default_generators</buildtool_depend>
-  <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/srv/ComputeCoordinate.srv
+++ b/srv/ComputeCoordinate.srv
@@ -1,0 +1,9 @@
+# Request
+reseq_interfaces/Detection detection
+sensor_msgs/CameraInfo camera_info
+string target_frame
+---
+# Response
+bool success
+geometry_msgs/PointStamped point
+string message

--- a/srv/GetStatus.srv
+++ b/srv/GetStatus.srv
@@ -1,0 +1,7 @@
+# Request
+# (empty)
+---
+uint8 current_mode
+bool initialized
+string csv_path
+string last_error

--- a/srv/SetMode.srv
+++ b/srv/SetMode.srv
@@ -1,0 +1,8 @@
+# Request
+uint8 mode           # 0=OFF,1=INITIALIZING,2=SENSOR_CRATE,3=MAPPING
+string csv_path
+---
+# Response
+bool success
+uint8 previous_mode
+string message


### PR DESCRIPTION
Implements the interface definitions required for the new detection manager system.

- Extended Detection.msg with bounding box, depth, and camera frame fields
- Added new services:
  • SetMode.srv
  • GetStatus.srv
  • ComputeCoordinate.srv
- Updated CMakeLists.txt and package.xml for build integration

Related to issue #87 of reseq_ros2 repo